### PR TITLE
docs: Improve Claude Desktop connection documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,60 @@ Example `mcp.json`
 }
 ```
 
-### Via a local proxy
+### Connecting Claude Desktop and Other STDIO-only Clients
 
-Since MetaMCP endpoints are remote only (SSE, Streamable HTTP, OpenAPI), for clients that only supports stdio servers then you can use a local proxy.
-Checkout https://www.npmjs.com/package/mcp-remote or https://github.com/metatool-ai/metamcp/issues/76#issuecomment-3046707532
+Since MetaMCP endpoints are remote only (SSE, Streamable HTTP, OpenAPI), clients that only support stdio servers (like Claude Desktop) need a local proxy to connect.
+
+**Note:** While `mcp-remote` is sometimes suggested for this purpose, it's designed for OAuth-based authentication and doesn't work with MetaMCP's API key authentication. Based on testing, `mcp-proxy` is the recommended solution.
+
+Here's a working configuration for Claude Desktop using `mcp-proxy`:
+
+```json
+{
+  "mcpServers": {
+    "your-endpoint-name": {
+      "command": "uvx",
+      "args": [
+        "mcp-proxy",
+        "http://localhost:12008/metamcp/YOUR_ENDPOINT_NAME/mcp",
+        "--transport=streamablehttp",
+        "-H",
+        "Authorization",
+        "Bearer YOUR_API_KEY_HERE"
+      ]
+    }
+  }
+}
+```
+
+**Important notes:**
+- Replace `YOUR_ENDPOINT_NAME` with your actual endpoint name
+- Replace `YOUR_API_KEY_HERE` with your MetaMCP API key (format: `sk_mt_...`)
+- Use `uvx` if you have it installed, otherwise use `npx -y` instead
+- The endpoint path must be `/mcp` for streamable HTTP (not `/sse`)
+- Headers are passed as separate arguments: `-H` `HeaderName` `HeaderValue`
+
+If you don't have `uvx`, use this configuration:
+```json
+{
+  "mcpServers": {
+    "your-endpoint-name": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-proxy",
+        "http://localhost:12008/metamcp/YOUR_ENDPOINT_NAME/mcp",
+        "--transport=streamablehttp",
+        "-H",
+        "Authorization",
+        "Bearer YOUR_API_KEY_HERE"
+      ]
+    }
+  }
+}
+```
+
+For more details and alternative approaches, see [issue #76](https://github.com/metatool-ai/metamcp/issues/76#issuecomment-3046707532).
 
 ### API Key Auth Troubleshooting
 


### PR DESCRIPTION
  This PR improves the documentation for connecting Claude Desktop to MetaMCP endpoints based on real-world testing and troubleshooting experience.

  Problem Investigation:

  When following the original documentation to connect Claude Desktop to MetaMCP, I encountered multiple issues. Here's what I tried and why each approach
  failed:

  1. Direct URL connection (as shown for Cursor)
    - Tried: Using the URL directly in Claude Desktop's config
    - Failed: Claude Desktop only supports STDIO-based servers, not remote URLs
    - Error: "Required" error for missing command field
  2. mcp-remote (as suggested in the docs)
    - Tried: Multiple configurations with mcp-remote
    - Failed: mcp-remote is designed for OAuth authentication, not API keys
    - Errors:
        - "Invalid URL" when using connect subcommand
      - "Unexpected token < in JSON" when trying to authenticate
      - 404 errors because it expected OAuth endpoints
  3. sse-client package
    - Tried: Using npx sse-client as a generic SSE proxy
    - Failed: Not an MCP-compatible proxy, just outputs raw SSE data
    - Error: "Unexpected token 'Y'" - Claude Desktop couldn't parse the output
  4. @modelcontextprotocol/client
    - Tried: Using the official MCP client package
    - Failed: Package doesn't exist on npm
    - Error: "404 Not Found - GET https://registry.npmjs.org/@modelcontextprotocol%2fclient"
  5. mcp-proxy with JSON headers
    - Tried: Passing headers as JSON object --headers '{"Authorization": "Bearer ..."}'
    - Failed: mcp-proxy expects separate key-value arguments
    - Error: "argument -H/--headers: expected 2 arguments"

  Solution:

  After extensive testing, I found that mcp-proxy works correctly when:
  - Using streamable HTTP transport (/mcp endpoint, not /sse)
  - Passing headers as separate arguments: -H Authorization "Bearer sk_mt_..."
  - Using either uvx or npx -y to run the proxy

  Changes Made:

  1. Restructured the documentation to clearly explain why stdio-only clients need a proxy
  2. Added a note explaining why mcp-remote doesn't work with API key authentication
  3. Provided complete, working examples with proper header formatting
  4. Included both uvx and npx variations for different user setups
  5. Maintained reference to the GitHub issue for additional context

  This documentation update will save future users from the same troubleshooting journey and provide a clear, working solution from the start.