### PR TITLE
2.3.6 Mitigate fast failed stdio

### DIFF
--- a/apps/backend/src/routers/mcp-proxy/server.ts
+++ b/apps/backend/src/routers/mcp-proxy/server.ts
@@ -33,7 +33,7 @@ const defaultEnvironment = {
 };
 
 // Cooldown mechanism for failed STDIO commands
-const STDIO_COOLDOWN_DURATION = 30000; // 30 seconds
+const STDIO_COOLDOWN_DURATION = 10000; // 10 seconds
 const stdioCommandCooldowns = new Map<string, number>();
 
 // Function to create a key for STDIO commands

--- a/apps/frontend/app/[locale]/(sidebar)/layout.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/layout.tsx
@@ -115,7 +115,7 @@ function UserInfoFooter() {
       <div className="flex flex-col gap-2 p-2">
         <div className="flex items-center justify-between">
           <LanguageSwitcher />
-          <p>Version v2.3.5</p>
+          <p>Version v2.3.6</p>
         </div>
         <Separator />
         {user && (

--- a/apps/frontend/app/[locale]/(sidebar)/mcp-servers/mcp-servers-list.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/mcp-servers/mcp-servers-list.tsx
@@ -138,6 +138,7 @@ export function McpServersList({ onRefresh }: McpServersListProps) {
   const columns: ColumnDef<McpServer>[] = [
     {
       accessorKey: "name",
+      size: 200,
       header: ({ column }) => {
         return (
           <Button
@@ -165,6 +166,7 @@ export function McpServersList({ onRefresh }: McpServersListProps) {
     },
     {
       accessorKey: "type",
+      size: 120,
       header: ({ column }) => {
         return (
           <Button
@@ -189,6 +191,7 @@ export function McpServersList({ onRefresh }: McpServersListProps) {
     },
     {
       accessorKey: "user_id",
+      size: 120,
       header: ({ column }) => {
         return (
           <Button
@@ -247,9 +250,12 @@ export function McpServersList({ onRefresh }: McpServersListProps) {
         }
 
         return (
-          <div className="text-sm space-y-1">
+          <div className="text-sm space-y-1 w-full">
             {details.map((detail, index) => (
-              <div key={index} className="text-muted-foreground">
+              <div
+                key={index}
+                className="text-muted-foreground break-words whitespace-normal overflow-wrap-anywhere"
+              >
                 {detail}
               </div>
             ))}
@@ -259,6 +265,7 @@ export function McpServersList({ onRefresh }: McpServersListProps) {
     },
     {
       accessorKey: "created_at",
+      size: 180,
       header: ({ column }) => {
         return (
           <Button
@@ -281,6 +288,7 @@ export function McpServersList({ onRefresh }: McpServersListProps) {
     },
     {
       id: "actions",
+      size: 100,
       header: t("mcp-servers:list.actions"),
       cell: ({ row }) => {
         const server = row.original;
@@ -523,7 +531,14 @@ export function McpServersList({ onRefresh }: McpServersListProps) {
                 <TableRow key={headerGroup.id}>
                   {headerGroup.headers.map((header) => {
                     return (
-                      <TableHead key={header.id}>
+                      <TableHead
+                        key={header.id}
+                        className={
+                          header.column.id === "details"
+                            ? "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-normal w-full [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]"
+                            : undefined
+                        }
+                      >
                         {header.isPlaceholder
                           ? null
                           : flexRender(
@@ -544,7 +559,14 @@ export function McpServersList({ onRefresh }: McpServersListProps) {
                     data-state={row.getIsSelected() && "selected"}
                   >
                     {row.getVisibleCells().map((cell) => (
-                      <TableCell key={cell.id}>
+                      <TableCell
+                        key={cell.id}
+                        className={
+                          cell.column.id === "details"
+                            ? "p-2 align-middle whitespace-normal w-full [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]"
+                            : undefined
+                        }
+                      >
                         {flexRender(
                           cell.column.columnDef.cell,
                           cell.getContext(),

--- a/apps/frontend/app/[locale]/(sidebar)/namespaces/[uuid]/components/namespace-servers-table.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/namespaces/[uuid]/components/namespace-servers-table.tsx
@@ -257,9 +257,12 @@ export function NamespaceServersTable({
         }
 
         return (
-          <div className="text-sm space-y-1">
+          <div className="text-sm space-y-1 w-full">
             {details.map((detail, index) => (
-              <div key={index} className="text-muted-foreground">
+              <div
+                key={index}
+                className="text-muted-foreground break-words whitespace-normal overflow-wrap-anywhere"
+              >
                 {detail}
               </div>
             ))}
@@ -435,7 +438,14 @@ export function NamespaceServersTable({
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => {
                   return (
-                    <TableHead key={header.id}>
+                    <TableHead
+                      key={header.id}
+                      className={
+                        header.column.id === "details"
+                          ? "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-normal w-full [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]"
+                          : undefined
+                      }
+                    >
                       {header.isPlaceholder
                         ? null
                         : flexRender(
@@ -456,7 +466,14 @@ export function NamespaceServersTable({
                   data-state={row.getIsSelected() && "selected"}
                 >
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
+                    <TableCell
+                      key={cell.id}
+                      className={
+                        cell.column.id === "details"
+                          ? "p-2 align-middle whitespace-normal w-full [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]"
+                          : undefined
+                      }
+                    >
                       {flexRender(
                         cell.column.columnDef.cell,
                         cell.getContext(),

--- a/apps/frontend/hooks/useConnection.ts
+++ b/apps/frontend/hooks/useConnection.ts
@@ -408,6 +408,13 @@ export function useConnection({
                   headers,
                   credentials: "include",
                 },
+                // TODO these should be configurable...
+                reconnectionOptions: {
+                  maxReconnectionDelay: 30000,
+                  initialReconnectionDelay: 1000,
+                  reconnectionDelayGrowFactor: 1.5,
+                  maxRetries: 2,
+                },
               };
               break;
 

--- a/apps/frontend/hooks/useConnection.ts
+++ b/apps/frontend/hooks/useConnection.ts
@@ -437,6 +437,13 @@ export function useConnection({
                   headers,
                   credentials: "include",
                 },
+                // TODO these should be configurable...
+                reconnectionOptions: {
+                  maxReconnectionDelay: 30000,
+                  initialReconnectionDelay: 1000,
+                  reconnectionDelayGrowFactor: 1.5,
+                  maxRetries: 2,
+                },
               };
               break;
 


### PR DESCRIPTION
- See https://github.com/metatool-ai/metamcp/issues/113 failed stdio server may infinitely reconnect in mcp-proxy (Frontend's MCP servers detail page and inspector)
- Mitigate this by adding a backend cooldown rate limit 10s to prevent infinite reconnection.
- More UX issue on the connection should be fixed but not yet.
- Small layout fix