### PR TITLE
 #141 Add support for ${ENV_VAR} resolution in STDIO MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,28 @@ A MCP server configuration that tells MetaMCP how to start a MCP server.
 }
 ```
 
+#### 🔐 **Environment Variables & Secrets (STDIO MCP Servers)**
+
+For **STDIO MCP servers**, MetaMCP supports three ways to handle environment variables and secrets:
+
+**1. Raw Values** - Direct string values (not recommended for secrets):
+```
+API_KEY=your-actual-api-key-here
+DEBUG=true
+```
+
+**2. Environment Variable References** - Use `${ENV_VAR_NAME}` syntax:
+```
+API_KEY=${OPENAI_API_KEY}
+DATABASE_URL=${DB_CONNECTION_STRING}
+```
+
+**3. Auto-matching** - If the expected environment variable name in your tool matches the container's environment variable, you can omit it entirely. MetaMCP will automatically pass through matching environment variables.
+
+> **🔒 Security Note**: Environment variable references (`${VAR_NAME}`) are resolved from the MetaMCP container's environment at runtime. This keeps actual secret values out of your configuration and git repository.
+
+> **⚙️ Development Note**: For local development with `pnpm run dev:docker`, ensure your environment variables are listed in `turbo.json` under `globalEnv` to be passed to the development processes. This is not required for production Docker deployments.
+
 ### 🏷️ **MetaMCP Namespace**
 - Group one or more MCP servers into a namespace
 - Enable/disable MCP servers or at tool level


### PR DESCRIPTION
## Description

Add support for `${ENV_VAR}` resolution in STDIO MCP servers

This PR introduces runtime environment variable resolution (e.g., `${API_KEY}`) for STDIO MCP server configurations, enabling secure secret handling via process.env.

### Highlights:
	•	Resolves `${VAR}` placeholders from process.env
	•	Redacts secrets in logs
	•	Graceful fallback if env var is missing
	•	Backward-compatible with existing configs
	•	Docs updated (README)

##  How to Test This Feature

To verify this feature, follow these steps:

### 1. Set up environment variables

Ensure the required environment variables are available in your shell before launching MetaMCP:

```
export TEST_SECRET="my-test-value"
export OPENAI_API_KEY="test-openai-key"
export DB_CONNECTION_STRING="postgres://user:pass@localhost:5432/db"
```

Make sure `pnpm run dev:docke`r is used to ensure environment variables are passed from `turbo.json`.

### 2. Test Raw Value (should still work but discouraged for secrets)

Edit or create a STDIO MCP server config:

```
API_KEY=raw-test-value
DEBUG=true
```

Start MetaMCP and confirm that the server receives these values as-is.

### 3. Test `${ENV_VAR}` Resolution

Use variable references in your STDIO MCP config:

```
API_KEY=${OPENAI_API_KEY}
DATABASE_URL=${DB_CONNECTION_STRING}
```

**Expected behavior**:
- These values are resolved at runtime using the MetaMCP container’s environment.
- They are passed correctly to the spawned STDIO process.

You can verify by printing the env inside your tool or checking the logs.

### 4. Test Redaction in Logs

Ensure secret values like `${OPENAI_API_KEY}` do not appear in logs in raw form.

**Expected log output:**

```
Resolved env var OPENAI_API_KEY=**** (redacted)
```

### 5. Test Auto-Matching Behavior

If the tool inside the STDIO container expects an API_KEY env variable and it’s already present in the MetaMCP container environment, omit it in the config:

```
# No API_KEY specified
```

**Expected behavior**:
- The tool still receives API_KEY from the container environment automatically.

### 6. Test Graceful Failure on Missing Vars

Use a non-existent environment variable:

```
SECRET_TOKEN=${MISSING_ENV_VAR}
```

**Expected behavior**:
- A warning is logged that `${MISSING_ENV_VAR}` is not defined.
- Either fallback behavior is applied, or the config fails to load (depending on tool behavior).
- No crash occurs.

Fixes: [#141](https://github.com/metatool-ai/metamcp/issues/141)