### PR TITLE
Fix nested MetaMCP tool name parsing

### DIFF
--- a/apps/backend/src/lib/metamcp/tool-name-parser.ts
+++ b/apps/backend/src/lib/metamcp/tool-name-parser.ts
@@ -3,7 +3,7 @@
  *
  * Tool names follow the format: {ServerPrefix}__{toolName}
  * Where ServerPrefix can be nested: Parent__Child__GrandChild
- * The last __ is always the separator between server prefix and actual tool name
+ * The first __ is always the separator between the top-level server prefix and the forwarded tool name
  */
 
 export interface ParsedToolName {
@@ -23,19 +23,19 @@ export interface ParsedToolName {
  *
  * @example
  * parseToolName("Parent__Child__my_tool")
- * // → { serverName: "Parent__Child", originalToolName: "my_tool" }
+ * // → { serverName: "Parent", originalToolName: "Child__my_tool" }
  */
 export function parseToolName(toolName: string): ParsedToolName | null {
-  const lastDoubleUnderscoreIndex = toolName.lastIndexOf("__");
-  if (lastDoubleUnderscoreIndex === -1) {
+  const firstDoubleUnderscoreIndex = toolName.indexOf("__");
+  if (firstDoubleUnderscoreIndex === -1) {
     return null;
   }
 
-  // The last __ is always the separator between the full server prefix and the actual tool name
-  // Everything before the last __ is the server prefix (which may contain nested servers)
-  // Everything after the last __ is the actual tool name
-  const serverName = toolName.substring(0, lastDoubleUnderscoreIndex);
-  const originalToolName = toolName.substring(lastDoubleUnderscoreIndex + 2);
+  // The first __ is always the separator between the top-level server prefix and the forwarded tool name
+  // Everything before the first __ is the server prefix (which may contain nested servers)
+  // Everything after the first __ is the forwarded tool name (which may itself include additional prefixes)
+  const serverName = toolName.substring(0, firstDoubleUnderscoreIndex);
+  const originalToolName = toolName.substring(firstDoubleUnderscoreIndex + 2);
 
   return {
     serverName,

--- a/apps/frontend/lib/tool-name-parser.ts
+++ b/apps/frontend/lib/tool-name-parser.ts
@@ -3,7 +3,7 @@
  *
  * Tool names follow the format: {ServerPrefix}__{toolName}
  * Where ServerPrefix can be nested: Parent__Child__GrandChild
- * The last __ is always the separator between server prefix and actual tool name
+ * The first __ is always the separator between the top-level server prefix and the forwarded tool name
  */
 
 export interface ParsedToolName {
@@ -23,19 +23,19 @@ export interface ParsedToolName {
  *
  * @example
  * parseToolName("Parent__Child__my_tool")
- * // → { serverName: "Parent__Child", originalToolName: "my_tool" }
+ * // → { serverName: "Parent", originalToolName: "Child__my_tool" }
  */
 export function parseToolName(toolName: string): ParsedToolName | null {
-  const lastDoubleUnderscoreIndex = toolName.lastIndexOf("__");
-  if (lastDoubleUnderscoreIndex === -1) {
+  const firstDoubleUnderscoreIndex = toolName.indexOf("__");
+  if (firstDoubleUnderscoreIndex === -1) {
     return null;
   }
 
-  // The last __ is always the separator between the full server prefix and the actual tool name
-  // Everything before the last __ is the server prefix (which may contain nested servers)
-  // Everything after the last __ is the actual tool name
-  const serverName = toolName.substring(0, lastDoubleUnderscoreIndex);
-  const originalToolName = toolName.substring(lastDoubleUnderscoreIndex + 2);
+  // The first __ is always the separator between the top-level server prefix and the forwarded tool name
+  // Everything before the first __ is the server prefix (which may contain nested servers)
+  // Everything after the first __ is the forwarded tool name (which may itself include additional prefixes)
+  const serverName = toolName.substring(0, firstDoubleUnderscoreIndex);
+  const originalToolName = toolName.substring(firstDoubleUnderscoreIndex + 2);
 
   return {
     serverName,

--- a/docs/cn/concepts/namespaces.mdx
+++ b/docs/cn/concepts/namespaces.mdx
@@ -60,7 +60,8 @@ MetaMCP 中的**命名空间**是 MCP 服务器的逻辑分组，允许您将多
 
 ### 工具命名约定
 
-工具遵循模式：`{ServerName}__{originalToolName}`
+工具遵循模式：`{ServerName}__{originalToolName}`。在串联 MetaMCP 网关时，
+`originalToolName` 本身可能包含嵌套前缀（例如 `OuterServer__InnerServer__my_tool`）。
 
 示例：来自 "WebSearch" 服务器的 `search` 工具变成 `WebSearch__search`
 

--- a/docs/en/concepts/namespaces.mdx
+++ b/docs/en/concepts/namespaces.mdx
@@ -60,7 +60,9 @@ When you create a namespace:
 
 ### Tool Naming Convention
 
-Tools follow the pattern: `{ServerName}__{originalToolName}`
+Tools follow the pattern: `{ServerName}__{originalToolName}`. When chaining
+MetaMCP gateways, `originalToolName` can itself contain nested prefixes (for
+example, `OuterServer__InnerServer__my_tool`).
 
 Example: A `search` tool from "WebSearch" server becomes `WebSearch__search`
 


### PR DESCRIPTION
Fixes #184

Change the last `__` to the first `__` while parsing the tool name.