### PR TITLE
feat(oauth): proxy downstream OAuth fetches through the backend so CORS-less OAuth MCP servers can be added

### DIFF
--- a/apps/backend/src/trpc/oauth.impl.ts
+++ b/apps/backend/src/trpc/oauth.impl.ts
@@ -1,6 +1,8 @@
 import {
   GetOAuthSessionRequestSchema,
   GetOAuthSessionResponseSchema,
+  OAuthProxyFetchRequestSchema,
+  OAuthProxyFetchResponseSchema,
   UpsertOAuthSessionRequestSchema,
   UpsertOAuthSessionResponseSchema,
 } from "@repo/zod-types";
@@ -8,7 +10,10 @@ import { z } from "zod";
 
 import logger from "@/utils/logger";
 
-import { oauthSessionsRepository } from "../db/repositories";
+import {
+  mcpServersRepository,
+  oauthSessionsRepository,
+} from "../db/repositories";
 import { OAuthSessionsSerializer } from "../db/serializers";
 
 export const oauthImplementations = {
@@ -71,6 +76,98 @@ export const oauthImplementations = {
       return {
         success: false as const,
         error: error instanceof Error ? error.message : "Internal server error",
+      };
+    }
+  },
+
+  // Server-side OAuth fetch proxy. The MCP OAuth flow (discovery, dynamic client
+  // registration, token exchange, refresh) is driven from the browser, which
+  // fails for upstream OAuth servers that don't send CORS headers. Routing those
+  // requests through the backend (server-to-server) avoids CORS entirely.
+  proxyFetch: async (
+    input: z.infer<typeof OAuthProxyFetchRequestSchema>,
+  ): Promise<z.infer<typeof OAuthProxyFetchResponseSchema>> => {
+    try {
+      const server = await mcpServersRepository.findByUuid(
+        input.mcp_server_uuid,
+      );
+      if (!server || !server.url) {
+        return {
+          success: false as const,
+          error: "MCP server not found or has no URL",
+        };
+      }
+
+      // SSRF guard: only proxy to the same host as the configured server URL,
+      // over https — the same host MetaMCP already connects to for MCP traffic.
+      const allowedHost = new URL(server.url).host;
+      const target = new URL(input.url);
+      if (target.protocol !== "https:" || target.host !== allowedHost) {
+        return {
+          success: false as const,
+          error: `Refusing to proxy OAuth request to ${target.host} (only https://${allowedHost} is allowed)`,
+        };
+      }
+
+      const forwardHeaders = (): Record<string, string> => {
+        const out: Record<string, string> = {};
+        for (const [key, value] of Object.entries(input.headers ?? {})) {
+          const lower = key.toLowerCase();
+          if (
+            ["host", "content-length", "cookie", "connection"].includes(lower)
+          ) {
+            continue;
+          }
+          out[key] = value;
+        }
+        return out;
+      };
+
+      const doFetch = (u: string) =>
+        fetch(u, {
+          method: input.method,
+          headers: forwardHeaders(),
+          body:
+            input.method === "GET" || input.method === "HEAD"
+              ? undefined
+              : input.body,
+          redirect: "follow",
+        });
+
+      let response = await doFetch(target.toString());
+
+      // Some providers advertise a protected-resource metadata URL with an extra
+      // path segment that 403/404s while the spec base path works. Retry base.
+      if (
+        (response.status === 403 || response.status === 404) &&
+        target.pathname.startsWith("/.well-known/oauth-protected-resource/")
+      ) {
+        const fallback = new URL(target.toString());
+        fallback.pathname = "/.well-known/oauth-protected-resource";
+        const fallbackResponse = await doFetch(fallback.toString());
+        if (fallbackResponse.ok) {
+          response = fallbackResponse;
+        }
+      }
+
+      const headers: Record<string, string> = {};
+      response.headers.forEach((value, key) => {
+        headers[key] = value;
+      });
+
+      return {
+        success: true as const,
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+        body: await response.text(),
+      };
+    } catch (error) {
+      logger.error("OAuth proxy fetch error:", error);
+      return {
+        success: false as const,
+        error:
+          error instanceof Error ? error.message : "OAuth proxy fetch failed",
       };
     }
   },

--- a/apps/frontend/components/OAuthCallback.tsx
+++ b/apps/frontend/components/OAuthCallback.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "@/hooks/useTranslations";
 
 import { getServerSpecificKey, SESSION_KEYS } from "../lib/constants";
 import { createAuthProvider } from "../lib/oauth-provider";
+import { createProxiedFetch } from "../lib/proxied-fetch";
 import { vanillaTrpcClient } from "../lib/trpc";
 
 const OAuthCallback = () => {
@@ -42,6 +43,7 @@ const OAuthCallback = () => {
         const result = await auth(authProvider, {
           serverUrl,
           authorizationCode: code,
+          fetchFn: createProxiedFetch(mcpServerUuid),
         });
 
         if (result !== "AUTHORIZED") {

--- a/apps/frontend/hooks/useConnection.ts
+++ b/apps/frontend/hooks/useConnection.ts
@@ -1,4 +1,9 @@
-import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
+import {
+  auth,
+  discoverOAuthMetadata,
+  discoverOAuthProtectedResourceMetadata,
+  registerClient,
+} from "@modelcontextprotocol/sdk/client/auth.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
   SSEClientTransport,
@@ -47,6 +52,7 @@ import {
   StdErrNotificationSchema,
 } from "../lib/notificationTypes";
 import { createAuthProvider } from "../lib/oauth-provider";
+import { createProxiedFetch } from "../lib/proxied-fetch";
 import { trpc } from "../lib/trpc";
 
 interface UseConnectionOptions {
@@ -300,8 +306,45 @@ export function useConnection({
       sessionStorage.setItem(SESSION_KEYS.SERVER_URL, url || "");
       sessionStorage.setItem(SESSION_KEYS.MCP_SERVER_UUID, mcpServerUuid);
 
+      // Route OAuth discovery/registration/token through the MetaMCP backend so
+      // it works with upstream OAuth servers that don't send CORS headers.
+      const fetchFn = createProxiedFetch(mcpServerUuid);
+
+      // Work around a bug in @modelcontextprotocol/sdk 1.16: auth() forwards
+      // fetchFn to discovery and token exchange but NOT to registerClient, so
+      // dynamic client registration falls back to the browser's fetch and is
+      // CORS-blocked. Pre-register the client here (these helpers DO honor
+      // fetchFn) so auth() finds existing client info and skips registration.
+      // (Fixed upstream in SDK >= 1.29; this block can be removed after a bump.)
+      if (
+        authProvider.saveClientInformation &&
+        !(await authProvider.clientInformation())
+      ) {
+        const resourceMetadata = await discoverOAuthProtectedResourceMetadata(
+          url || "",
+          {},
+          fetchFn,
+        ).catch(() => undefined);
+        const authorizationServerUrl =
+          resourceMetadata?.authorization_servers?.[0] ?? url ?? "";
+        const metadata = await discoverOAuthMetadata(
+          url || "",
+          { authorizationServerUrl },
+          fetchFn,
+        );
+        if (metadata) {
+          const fullInformation = await registerClient(authorizationServerUrl, {
+            metadata,
+            clientMetadata: authProvider.clientMetadata,
+            fetchFn,
+          });
+          await authProvider.saveClientInformation(fullInformation);
+        }
+      }
+
       const result = await auth(authProvider, {
         serverUrl: url || "",
+        fetchFn,
       });
       return result === "AUTHORIZED";
     }

--- a/apps/frontend/lib/oauth-provider.ts
+++ b/apps/frontend/lib/oauth-provider.ts
@@ -20,8 +20,13 @@ class DbOAuthClientProvider implements OAuthClientProvider {
   constructor(mcpServerUuid: string, serverUrl: string) {
     this.mcpServerUuid = mcpServerUuid;
     this.serverUrl = serverUrl;
-    // Save the server URL to session storage for consistency
-    sessionStorage.setItem(SESSION_KEYS.SERVER_URL, serverUrl);
+    // Save the server URL to session storage for consistency. Guard for SSR:
+    // this provider is constructed during render (useConnection) of pages that
+    // are server-rendered, where sessionStorage is undefined — accessing it
+    // there throws and 500s the page (e.g. the post-OAuth redirect target).
+    if (typeof window !== "undefined") {
+      sessionStorage.setItem(SESSION_KEYS.SERVER_URL, serverUrl);
+    }
   }
 
   get redirectUrl() {

--- a/apps/frontend/lib/proxied-fetch.ts
+++ b/apps/frontend/lib/proxied-fetch.ts
@@ -1,0 +1,61 @@
+import { vanillaTrpcClient } from "./trpc";
+
+// Statuses for which the Response constructor forbids a body.
+const NULL_BODY_STATUS = new Set([101, 103, 204, 205, 304]);
+
+/**
+ * Returns a fetch-compatible function (FetchLike) that routes the request
+ * through the MetaMCP backend (server-to-server) instead of issuing it from the
+ * browser.
+ *
+ * Used for the OAuth flow against an upstream MCP server — discovery, dynamic
+ * client registration, and token exchange/refresh. Performing those from the
+ * browser fails for any provider that doesn't send CORS headers (common for
+ * enterprise OAuth servers); doing them server-side avoids CORS entirely. The
+ * backend also transparently works around providers that advertise a broken
+ * protected-resource metadata URL.
+ */
+export function createProxiedFetch(mcpServerUuid: string) {
+  return async (input: string | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      new Headers(init.headers).forEach((value, key) => {
+        headers[key] = value;
+      });
+    }
+
+    let body: string | undefined;
+    if (init?.body != null) {
+      body =
+        typeof init.body === "string"
+          ? init.body
+          : init.body instanceof URLSearchParams
+            ? init.body.toString()
+            : String(init.body);
+    }
+
+    const result = await vanillaTrpcClient.frontend.oauth.proxyFetch.mutate({
+      mcp_server_uuid: mcpServerUuid,
+      url,
+      method,
+      headers,
+      body,
+    });
+
+    if (!result.success) {
+      throw new Error(`OAuth proxy fetch failed: ${result.error}`);
+    }
+
+    return new Response(
+      NULL_BODY_STATUS.has(result.status) ? null : result.body,
+      {
+        status: result.status,
+        statusText: result.statusText,
+        headers: result.headers,
+      },
+    );
+  };
+}

--- a/packages/trpc/src/routers/frontend/oauth.ts
+++ b/packages/trpc/src/routers/frontend/oauth.ts
@@ -1,6 +1,8 @@
 import {
   GetOAuthSessionRequestSchema,
   GetOAuthSessionResponseSchema,
+  OAuthProxyFetchRequestSchema,
+  OAuthProxyFetchResponseSchema,
   UpsertOAuthSessionRequestSchema,
   UpsertOAuthSessionResponseSchema,
 } from "@repo/zod-types";
@@ -19,6 +21,9 @@ export const createOAuthRouter = (
     upsert: (
       input: z.infer<typeof UpsertOAuthSessionRequestSchema>,
     ) => Promise<z.infer<typeof UpsertOAuthSessionResponseSchema>>;
+    proxyFetch: (
+      input: z.infer<typeof OAuthProxyFetchRequestSchema>,
+    ) => Promise<z.infer<typeof OAuthProxyFetchResponseSchema>>;
   },
 ) => {
   return router({
@@ -36,6 +41,14 @@ export const createOAuthRouter = (
       .output(UpsertOAuthSessionResponseSchema)
       .mutation(async ({ input }) => {
         return await implementations.upsert(input);
+      }),
+
+    // Protected: Server-side OAuth fetch proxy (for CORS-less upstream servers)
+    proxyFetch: protectedProcedure
+      .input(OAuthProxyFetchRequestSchema)
+      .output(OAuthProxyFetchResponseSchema)
+      .mutation(async ({ input }) => {
+        return await implementations.proxyFetch(input);
       }),
   });
 };

--- a/packages/zod-types/src/oauth.zod.ts
+++ b/packages/zod-types/src/oauth.zod.ts
@@ -149,6 +149,34 @@ export const UpsertOAuthSessionResponseSchema = z.union([
   }),
 ]);
 
+// ---------------------------------------------------------------------------
+// Server-side OAuth fetch proxy
+// Routes an MCP server's OAuth HTTP (discovery / dynamic client registration /
+// token exchange / refresh) through the MetaMCP backend instead of the browser,
+// so it works with upstream OAuth servers that do not send CORS headers.
+// ---------------------------------------------------------------------------
+export const OAuthProxyFetchRequestSchema = z.object({
+  mcp_server_uuid: z.string().uuid(),
+  url: z.string().url(),
+  method: z.string().default("GET"),
+  headers: z.record(z.string()).optional(),
+  body: z.string().optional(),
+});
+
+export const OAuthProxyFetchResponseSchema = z.union([
+  z.object({
+    success: z.literal(true),
+    status: z.number(),
+    statusText: z.string(),
+    headers: z.record(z.string()),
+    body: z.string(),
+  }),
+  z.object({
+    success: z.literal(false),
+    error: z.string(),
+  }),
+]);
+
 // Repository-specific schemas
 export const OAuthSessionCreateInputSchema = z.object({
   mcp_server_uuid: z.string(),


### PR DESCRIPTION
## Problem

MetaMCP can't connect to a remote MCP server whose OAuth provider doesn't send CORS headers. The OAuth flow — protected-resource/authorization-server discovery, dynamic client registration, token exchange/refresh — runs in the **browser** via the SDK's `auth()`. When the provider's `/.well-known/*`, registration, and token endpoints lack `Access-Control-Allow-Origin`, those browser `fetch`es are blocked, so authorization can never complete and the server is stuck "Disconnected/Connection Error".

This is common for enterprise OAuth servers. The case that motivated this: an IT-documentation SaaS whose MCP endpoint advertises `…/.well-known/oauth-protected-resource/<path>` (which 4xxs) and serves no CORS headers on any OAuth endpoint. It works in hosted clients (which authenticate server-side) but never in a self-hosted gateway.

## Fix

Route the OAuth HTTP requests through the MetaMCP backend (server-to-server, no CORS). The user-facing consent redirect stays in the browser as before.

- **`frontend.oauth.proxyFetch`** — new session-protected tRPC procedure that performs an OAuth HTTP request server-side. SSRF-guarded: only proxies to the configured MCP server's own host over https. Transparently retries the spec base `/.well-known/oauth-protected-resource` path when a provider advertises a sub-path that returns 4xx.
- **`createProxiedFetch`** — a `FetchLike` wrapper that calls the above and returns a real `Response`, passed as `auth()`'s `fetchFn` from the connection hook and the OAuth callback so discovery and token exchange run server-side.
- **Pre-register the OAuth client** via the SDK's exported `discoverOAuthProtectedResourceMetadata` / `discoverOAuthMetadata` / `registerClient` (which honor `fetchFn`) before calling `auth()`, so `auth()` finds existing client info and skips its own registration. This works around `@modelcontextprotocol/sdk` 1.16 not forwarding `fetchFn` to `registerClient` (fixed upstream in SDK ≥ 1.29 — the preamble can be dropped after a SDK bump).
- **SSR guard** in `DbOAuthClientProvider`'s constructor: it touched `sessionStorage` during render, which 500s any server-rendered page using `useConnection` (notably the post-OAuth redirect target). Guarded with `typeof window !== "undefined"`.

## Files
- `packages/zod-types/src/oauth.zod.ts` — proxy request/response schemas
- `packages/trpc/src/routers/frontend/oauth.ts` — `proxyFetch` procedure
- `apps/backend/src/trpc/oauth.impl.ts` — server-side fetch + SSRF guard + discovery fallback
- `apps/frontend/lib/proxied-fetch.ts` — `FetchLike` wrapper (new)
- `apps/frontend/hooks/useConnection.ts` — pre-register client + pass `fetchFn`
- `apps/frontend/components/OAuthCallback.tsx` — pass `fetchFn`
- `apps/frontend/lib/oauth-provider.ts` — SSR `sessionStorage` guard

## Testing

Built an image from this branch and ran it against a real CORS-less OAuth MCP server (Streamable HTTP).
- **Before:** Connect → `Access to fetch at '…/api/oauth/register' … blocked by CORS` → "Connection Error".
- **After:** Connect → server-side discovery + dynamic client registration → browser redirect to the provider's consent → callback → token stored → server shows **Connected**, tools enumerate, and the backend connects upstream with the bearer token (no 401). The post-OAuth detail page no longer 500s.

## Notes
- The SSRF guard restricts proxying to the MCP server's own host. If a provider's authorization server lives on a different host than the resource, that host would also need allowing (not handled here; straightforward to extend).
- An alternative to the registration preamble is bumping `@modelcontextprotocol/sdk` to ≥ 1.29; kept as a self-contained workaround to avoid a large dependency jump in this PR.
