### PR TITLE
feat(namespaces): export a namespace as portable, versioned JSON

### DIFF
--- a/apps/backend/src/lib/admin-mcp/tools-registry.ts
+++ b/apps/backend/src/lib/admin-mcp/tools-registry.ts
@@ -7,6 +7,7 @@ import {
   CreateNamespaceRequestSchema,
   CreateToolRequestSchema,
   DeleteApiKeyRequestSchema,
+  ExportNamespaceRequestSchema,
   GetLogsRequestSchema,
   GetNamespaceToolsRequestSchema,
   GetOAuthSessionRequestSchema,
@@ -216,6 +217,16 @@ export const ADMIN_TOOLS: AdminToolDefinition[] = [
     async (userId, input) =>
       namespacesImplementations.refreshTools(
         RefreshNamespaceToolsRequestSchema.parse(input),
+        userId,
+      ),
+  ),
+  defineTool(
+    "metamcp_export_namespace",
+    "Export a namespace as a portable, versioned JSON document. References servers and tools by name and contains no secrets.",
+    ExportNamespaceRequestSchema,
+    async (userId, input) =>
+      namespacesImplementations.export(
+        ExportNamespaceRequestSchema.parse(input),
         userId,
       ),
   ),

--- a/apps/backend/src/trpc/namespace-export.test.ts
+++ b/apps/backend/src/trpc/namespace-export.test.ts
@@ -1,0 +1,243 @@
+import type {
+  DatabaseNamespaceTool,
+  DatabaseNamespaceWithServers,
+} from "@repo/zod-types";
+import { describe, expect, it } from "vitest";
+
+import { buildNamespaceExport } from "./namespace-export";
+
+const FIXED_NOW = new Date("2026-07-31T10:00:00.000Z");
+
+function makeServer(
+  overrides: Partial<DatabaseNamespaceWithServers["servers"][number]> = {},
+): DatabaseNamespaceWithServers["servers"][number] {
+  return {
+    uuid: "server-uuid",
+    name: "github",
+    description: null,
+    type: "STDIO",
+    command: "node",
+    args: [],
+    url: null,
+    env: {},
+    bearerToken: null,
+    headers: {},
+    forward_headers: {},
+    created_at: FIXED_NOW,
+    user_id: "user-1",
+    status: "ACTIVE",
+    ...overrides,
+  };
+}
+
+function makeNamespace(
+  overrides: Partial<DatabaseNamespaceWithServers> = {},
+): DatabaseNamespaceWithServers {
+  return {
+    uuid: "ns-uuid",
+    name: "release-manager",
+    description: null,
+    created_at: FIXED_NOW,
+    updated_at: FIXED_NOW,
+    user_id: "user-1",
+    servers: [],
+    ...overrides,
+  };
+}
+
+function makeTool(
+  overrides: Partial<DatabaseNamespaceTool> = {},
+): DatabaseNamespaceTool {
+  return {
+    uuid: "tool-uuid",
+    name: "create_pull_request",
+    description: "Create a PR",
+    toolSchema: { type: "object", properties: {} },
+    created_at: FIXED_NOW,
+    updated_at: FIXED_NOW,
+    mcp_server_uuid: "server-uuid",
+    status: "ACTIVE",
+    serverName: "github",
+    serverUuid: "server-uuid",
+    overrideName: null,
+    overrideTitle: null,
+    overrideDescription: null,
+    overrideAnnotations: null,
+    ...overrides,
+  };
+}
+
+describe("buildNamespaceExport", () => {
+  it("exports servers, active/inactive tools and overrides", () => {
+    const namespace = makeNamespace({
+      description: "Tools for release coordination",
+      servers: [
+        makeServer({ name: "github", status: "ACTIVE" }),
+        makeServer({ name: "jira", status: "INACTIVE", uuid: "jira-uuid" }),
+      ],
+    });
+    const tools: DatabaseNamespaceTool[] = [
+      // Plain ACTIVE, no override -> omitted (default state).
+      makeTool({ name: "list_issues", status: "ACTIVE" }),
+      // Override present -> included.
+      makeTool({
+        name: "create_pull_request",
+        status: "ACTIVE",
+        overrideDescription: "Create a PR into the release branch.",
+        overrideAnnotations: { readOnlyHint: false },
+      }),
+      // INACTIVE -> included.
+      makeTool({ name: "delete_repository", status: "INACTIVE" }),
+    ];
+
+    const result = buildNamespaceExport(namespace, tools, { now: FIXED_NOW });
+
+    expect(result).toEqual({
+      version: 1,
+      exportedAt: "2026-07-31T10:00:00.000Z",
+      namespace: {
+        name: "release-manager",
+        description: "Tools for release coordination",
+        servers: [
+          { name: "github", status: "ACTIVE" },
+          { name: "jira", status: "INACTIVE" },
+        ],
+        tools: [
+          {
+            server: "github",
+            name: "create_pull_request",
+            status: "ACTIVE",
+            override: {
+              description: "Create a PR into the release branch.",
+              annotations: { readOnlyHint: false },
+            },
+          },
+          {
+            server: "github",
+            name: "delete_repository",
+            status: "INACTIVE",
+          },
+        ],
+      },
+    });
+  });
+
+  it("exports an empty namespace", () => {
+    const result = buildNamespaceExport(makeNamespace(), [], {
+      now: FIXED_NOW,
+    });
+
+    expect(result).toEqual({
+      version: 1,
+      exportedAt: "2026-07-31T10:00:00.000Z",
+      namespace: {
+        name: "release-manager",
+        servers: [],
+        tools: [],
+      },
+    });
+  });
+
+  it("never includes secret material", () => {
+    const namespace = makeNamespace({
+      servers: [
+        makeServer({
+          name: "github",
+          env: { GITHUB_TOKEN: "super-secret-env-value" },
+          bearerToken: "super-secret-bearer-token",
+          headers: { Authorization: "Bearer super-secret-header" },
+        }),
+      ],
+    });
+
+    const json = JSON.stringify(
+      buildNamespaceExport(namespace, [], { now: FIXED_NOW }),
+    );
+
+    expect(json).not.toContain("super-secret-env-value");
+    expect(json).not.toContain("super-secret-bearer-token");
+    expect(json).not.toContain("super-secret-header");
+    expect(json).not.toContain("GITHUB_TOKEN");
+    expect(json).not.toContain("bearerToken");
+    expect(json).not.toContain("headers");
+    expect(json).not.toContain("env");
+  });
+
+  it("produces deterministic, sorted, byte-identical output", () => {
+    const namespace = makeNamespace({
+      servers: [
+        makeServer({ name: "jira", uuid: "jira-uuid" }),
+        makeServer({ name: "github", uuid: "github-uuid" }),
+      ],
+    });
+    const tools: DatabaseNamespaceTool[] = [
+      makeTool({
+        serverName: "jira",
+        name: "create_issue",
+        status: "INACTIVE",
+      }),
+      makeTool({
+        serverName: "github",
+        name: "delete_repository",
+        status: "INACTIVE",
+      }),
+      makeTool({
+        serverName: "github",
+        name: "create_pull_request",
+        status: "INACTIVE",
+      }),
+    ];
+
+    const first = JSON.stringify(
+      buildNamespaceExport(namespace, tools, { now: FIXED_NOW }),
+      null,
+      2,
+    );
+    const second = JSON.stringify(
+      buildNamespaceExport(namespace, tools, { now: FIXED_NOW }),
+      null,
+      2,
+    );
+
+    expect(first).toBe(second);
+
+    const parsed = JSON.parse(first);
+    expect(
+      parsed.namespace.servers.map((s: { name: string }) => s.name),
+    ).toEqual(["github", "jira"]);
+    expect(
+      parsed.namespace.tools.map(
+        (t: { server: string; name: string }) => `${t.server}/${t.name}`,
+      ),
+    ).toEqual([
+      "github/create_pull_request",
+      "github/delete_repository",
+      "jira/create_issue",
+    ]);
+  });
+
+  it("sorts override annotation keys for stable output", () => {
+    const namespace = makeNamespace({
+      servers: [makeServer({ name: "github" })],
+    });
+    const tools: DatabaseNamespaceTool[] = [
+      makeTool({
+        name: "create_pull_request",
+        overrideAnnotations: {
+          readOnlyHint: false,
+          destructiveHint: true,
+          annotationTitle: "PR",
+        },
+      }),
+    ];
+
+    const result = buildNamespaceExport(namespace, tools, { now: FIXED_NOW });
+
+    const annotations = result.namespace.tools[0]?.override?.annotations ?? {};
+    expect(Object.keys(annotations)).toEqual([
+      "annotationTitle",
+      "destructiveHint",
+      "readOnlyHint",
+    ]);
+  });
+});

--- a/apps/backend/src/trpc/namespace-export.test.ts
+++ b/apps/backend/src/trpc/namespace-export.test.ts
@@ -216,6 +216,26 @@ describe("buildNamespaceExport", () => {
     ]);
   });
 
+  it("keeps the namespace body identical regardless of the export clock", () => {
+    const namespace = makeNamespace({
+      servers: [makeServer({ name: "github" })],
+    });
+    const tools: DatabaseNamespaceTool[] = [
+      makeTool({ name: "delete_repository", status: "INACTIVE" }),
+    ];
+
+    const a = buildNamespaceExport(namespace, tools, {
+      now: new Date("2026-07-31T10:00:00.000Z"),
+    });
+    const b = buildNamespaceExport(namespace, tools, {
+      now: new Date("2027-01-01T00:00:00.000Z"),
+    });
+
+    // Only exportedAt varies; the reviewable body is byte-identical.
+    expect(a.exportedAt).not.toBe(b.exportedAt);
+    expect(JSON.stringify(a.namespace)).toBe(JSON.stringify(b.namespace));
+  });
+
   it("sorts override annotation keys for stable output", () => {
     const namespace = makeNamespace({
       servers: [makeServer({ name: "github" })],

--- a/apps/backend/src/trpc/namespace-export.test.ts
+++ b/apps/backend/src/trpc/namespace-export.test.ts
@@ -216,6 +216,69 @@ describe("buildNamespaceExport", () => {
     ]);
   });
 
+  it("is deterministic when two servers share a name", () => {
+    // Server names are unique per user, so a public server and the caller's own
+    // private server can share a name inside one namespace. The underlying
+    // query has no ORDER BY, so row order must not reach the output.
+    const publicServer = makeServer({
+      uuid: "public-uuid",
+      name: "github",
+      user_id: null,
+      status: "ACTIVE",
+    });
+    const privateServer = makeServer({
+      uuid: "private-uuid",
+      name: "github",
+      user_id: "user-1",
+      status: "INACTIVE",
+    });
+
+    const oneOrder = buildNamespaceExport(
+      makeNamespace({ servers: [publicServer, privateServer] }),
+      [],
+      { now: FIXED_NOW },
+    );
+    const otherOrder = buildNamespaceExport(
+      makeNamespace({ servers: [privateServer, publicServer] }),
+      [],
+      { now: FIXED_NOW },
+    );
+
+    expect(JSON.stringify(oneOrder.namespace)).toBe(
+      JSON.stringify(otherOrder.namespace),
+    );
+  });
+
+  it("is deterministic when two tools share a server and tool name", () => {
+    const namespace = makeNamespace({
+      servers: [makeServer({ name: "github" })],
+    });
+    const inactive = makeTool({
+      uuid: "tool-a",
+      serverName: "github",
+      name: "create_pull_request",
+      status: "INACTIVE",
+    });
+    const overridden = makeTool({
+      uuid: "tool-b",
+      serverName: "github",
+      name: "create_pull_request",
+      status: "ACTIVE",
+      overrideDescription: "Use the release template.",
+    });
+
+    const oneOrder = buildNamespaceExport(namespace, [inactive, overridden], {
+      now: FIXED_NOW,
+    });
+    const otherOrder = buildNamespaceExport(namespace, [overridden, inactive], {
+      now: FIXED_NOW,
+    });
+
+    expect(JSON.stringify(oneOrder.namespace)).toBe(
+      JSON.stringify(otherOrder.namespace),
+    );
+  });
+
   it("keeps the namespace body identical regardless of the export clock", () => {
     const namespace = makeNamespace({
       servers: [makeServer({ name: "github" })],

--- a/apps/backend/src/trpc/namespace-export.ts
+++ b/apps/backend/src/trpc/namespace-export.ts
@@ -27,9 +27,19 @@ export function buildNamespaceExport(
 ): NamespaceExport {
   const exportedAt = (options.now ?? new Date()).toISOString();
 
+  // Sorting compares every exported field, not just the name. A namespace can
+  // legitimately hold two servers with the same name (server names are unique
+  // per user, so a public server and the caller's own private server may share
+  // one), and the underlying query has no ORDER BY. Ordering on name alone
+  // would leave those entries in database row order, which Postgres does not
+  // guarantee. With a total order over the exported content, entries that still
+  // tie are byte-identical, so their order cannot change the output.
   const servers: NamespaceExportServerEntry[] = namespace.servers
     .map((server) => ({ name: server.name, status: server.status }))
-    .sort((a, b) => compareStrings(a.name, b.name));
+    .sort(
+      (a, b) =>
+        compareStrings(a.name, b.name) || compareStrings(a.status, b.status),
+    );
 
   // Export only tools that deviate from the default (INACTIVE or with an
   // override). Plain ACTIVE tools with no override are the default and are
@@ -42,7 +52,10 @@ export function buildNamespaceExport(
     .filter((tool) => tool.status === "INACTIVE" || tool.override !== undefined)
     .sort(
       (a, b) =>
-        compareStrings(a.server, b.server) || compareStrings(a.name, b.name),
+        compareStrings(a.server, b.server) ||
+        compareStrings(a.name, b.name) ||
+        compareStrings(a.status, b.status) ||
+        compareStrings(serializeOverride(a), serializeOverride(b)),
     );
 
   return {
@@ -62,6 +75,13 @@ export function buildNamespaceExport(
 // locale. This matters because the document is meant to be portable.
 function compareStrings(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
+}
+
+// Last-resort tiebreaker for tools that match on server, name and status. The
+// override already has sorted keys and a fixed field order, so serializing it
+// yields a stable comparison key.
+function serializeOverride(tool: NamespaceExportToolEntry): string {
+  return JSON.stringify(tool.override ?? null);
 }
 
 function buildExportTool(

--- a/apps/backend/src/trpc/namespace-export.ts
+++ b/apps/backend/src/trpc/namespace-export.ts
@@ -1,0 +1,117 @@
+import {
+  DatabaseNamespaceTool,
+  DatabaseNamespaceWithServers,
+  NAMESPACE_EXPORT_VERSION,
+  NamespaceExport,
+  NamespaceExportServerEntry,
+  NamespaceExportToolEntry,
+  NamespaceExportToolOverride,
+} from "@repo/zod-types";
+
+export interface BuildNamespaceExportOptions {
+  // Injected so the timestamp is deterministic in tests. Defaults to now.
+  now?: Date;
+}
+
+// Builds the portable export document for a namespace. Pure and secret-free: it
+// reads only server/tool names, statuses and overrides, never server connection
+// config (env / bearer token / headers). Output is deterministic for a fixed
+// clock (servers sorted by name, tools by server then name, stable key order),
+// so two exports of the same namespace produce byte-identical JSON.
+export function buildNamespaceExport(
+  namespace: DatabaseNamespaceWithServers,
+  tools: DatabaseNamespaceTool[],
+  options: BuildNamespaceExportOptions = {},
+): NamespaceExport {
+  const exportedAt = (options.now ?? new Date()).toISOString();
+
+  const servers: NamespaceExportServerEntry[] = namespace.servers
+    .map((server) => ({ name: server.name, status: server.status }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  // Only export tools that deviate from the default (INACTIVE or with an
+  // override). Plain ACTIVE tools with no override are the default and are
+  // omitted to keep the document small and decoupled from the full,
+  // frequently-changing discovered-tool list.
+  const exportTools: NamespaceExportToolEntry[] = tools
+    .filter(isToolDeviation)
+    .map(buildExportTool)
+    .sort(
+      (a, b) =>
+        a.server.localeCompare(b.server) || a.name.localeCompare(b.name),
+    );
+
+  return {
+    version: NAMESPACE_EXPORT_VERSION,
+    exportedAt,
+    namespace: {
+      name: namespace.name,
+      ...(namespace.description ? { description: namespace.description } : {}),
+      servers,
+      tools: exportTools,
+    },
+  };
+}
+
+function isToolDeviation(tool: DatabaseNamespaceTool): boolean {
+  return tool.status === "INACTIVE" || buildOverride(tool) !== undefined;
+}
+
+function buildExportTool(
+  tool: DatabaseNamespaceTool,
+): NamespaceExportToolEntry {
+  const override = buildOverride(tool);
+  return {
+    server: tool.serverName,
+    name: tool.name,
+    status: tool.status,
+    ...(override ? { override } : {}),
+  };
+}
+
+// Collects the non-null override fields into a compact object, omitting empty
+// annotations. Returns undefined when there is no override at all.
+function buildOverride(
+  tool: DatabaseNamespaceTool,
+): NamespaceExportToolOverride | undefined {
+  const override: NamespaceExportToolOverride = {};
+  if (tool.overrideName != null) {
+    override.name = tool.overrideName;
+  }
+  if (tool.overrideTitle != null) {
+    override.title = tool.overrideTitle;
+  }
+  if (tool.overrideDescription != null) {
+    override.description = tool.overrideDescription;
+  }
+  if (
+    tool.overrideAnnotations != null &&
+    Object.keys(tool.overrideAnnotations).length > 0
+  ) {
+    // Sort keys so the annotations passthrough is byte-identical regardless of
+    // the key order the object happens to arrive in (the rest of the document
+    // already has a fixed key order).
+    override.annotations = sortKeysDeep(tool.overrideAnnotations) as Record<
+      string,
+      unknown
+    >;
+  }
+  return Object.keys(override).length > 0 ? override : undefined;
+}
+
+// Recursively sorts object keys so equal data serializes identically. Arrays
+// keep their order; primitives are returned as-is.
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortKeysDeep);
+  }
+  if (value !== null && typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+}

--- a/apps/backend/src/trpc/namespace-export.ts
+++ b/apps/backend/src/trpc/namespace-export.ts
@@ -15,9 +15,11 @@ export interface BuildNamespaceExportOptions {
 
 // Builds the portable export document for a namespace. Pure and secret-free: it
 // reads only server/tool names, statuses and overrides, never server connection
-// config (env / bearer token / headers). Output is deterministic for a fixed
-// clock (servers sorted by name, tools by server then name, stable key order),
-// so two exports of the same namespace produce byte-identical JSON.
+// config (env / bearer token / headers). The `namespace` body is deterministic:
+// it is byte-identical across exports of an unchanged namespace (servers sorted
+// by name, tools by server then name, stable key order, sorted annotation keys,
+// locale-independent comparison). Only the top-level `exportedAt` provenance
+// timestamp varies between exports.
 export function buildNamespaceExport(
   namespace: DatabaseNamespaceWithServers,
   tools: DatabaseNamespaceTool[],
@@ -27,18 +29,20 @@ export function buildNamespaceExport(
 
   const servers: NamespaceExportServerEntry[] = namespace.servers
     .map((server) => ({ name: server.name, status: server.status }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .sort((a, b) => compareStrings(a.name, b.name));
 
-  // Only export tools that deviate from the default (INACTIVE or with an
+  // Export only tools that deviate from the default (INACTIVE or with an
   // override). Plain ACTIVE tools with no override are the default and are
   // omitted to keep the document small and decoupled from the full,
-  // frequently-changing discovered-tool list.
+  // frequently-changing discovered-tool list. Build each entry once (which
+  // resolves the override) before filtering, so the override is not computed
+  // twice per tool.
   const exportTools: NamespaceExportToolEntry[] = tools
-    .filter(isToolDeviation)
     .map(buildExportTool)
+    .filter((tool) => tool.status === "INACTIVE" || tool.override !== undefined)
     .sort(
       (a, b) =>
-        a.server.localeCompare(b.server) || a.name.localeCompare(b.name),
+        compareStrings(a.server, b.server) || compareStrings(a.name, b.name),
     );
 
   return {
@@ -53,8 +57,11 @@ export function buildNamespaceExport(
   };
 }
 
-function isToolDeviation(tool: DatabaseNamespaceTool): boolean {
-  return tool.status === "INACTIVE" || buildOverride(tool) !== undefined;
+// Locale-independent string comparison (code-unit order) so the ordering is
+// stable across Node runtimes and instances, not dependent on the ambient ICU
+// locale. This matters because the document is meant to be portable.
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 function buildExportTool(

--- a/apps/backend/src/trpc/namespaces.impl.test.ts
+++ b/apps/backend/src/trpc/namespaces.impl.test.ts
@@ -1,0 +1,113 @@
+import type { DatabaseNamespaceWithServers } from "@repo/zod-types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// vitest hoists vi.mock() above imports so namespaces.impl loads against these
+// stubs instead of the real repositories / server pool. The pool and the
+// tool-override middleware both pull in db/index (which throws without
+// DATABASE_URL) and start timers, so they are mocked out here; the export path
+// only touches namespacesRepository.
+vi.mock("../db/repositories", () => ({
+  namespacesRepository: {
+    findByUuidWithServers: vi.fn(),
+    findToolsByNamespaceUuid: vi.fn(),
+  },
+  mcpServersRepository: {},
+  namespaceMappingsRepository: {},
+  toolsRepository: {},
+}));
+
+vi.mock("../db/serializers", () => ({
+  NamespacesSerializer: {},
+}));
+
+vi.mock("../lib/metamcp/metamcp-middleware/tool-overrides.functional", () => ({
+  clearOverrideCache: vi.fn(),
+  mapOverrideNameToOriginal: vi.fn(),
+}));
+
+vi.mock("../lib/metamcp/metamcp-server-pool", () => ({
+  metaMcpServerPool: {},
+}));
+
+vi.mock("@/utils/logger", () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { namespacesRepository } from "../db/repositories";
+import { namespacesImplementations } from "./namespaces.impl";
+
+const findByUuidWithServers = vi.mocked(
+  namespacesRepository.findByUuidWithServers,
+);
+const findToolsByNamespaceUuid = vi.mocked(
+  namespacesRepository.findToolsByNamespaceUuid,
+);
+
+function namespaceOwnedBy(userId: string | null): DatabaseNamespaceWithServers {
+  return {
+    uuid: "ns-uuid",
+    name: "release-manager",
+    description: null,
+    created_at: new Date("2026-07-31T10:00:00.000Z"),
+    updated_at: new Date("2026-07-31T10:00:00.000Z"),
+    user_id: userId,
+    servers: [],
+  };
+}
+
+describe("namespacesImplementations.export", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findToolsByNamespaceUuid.mockResolvedValue([]);
+  });
+
+  it("denies exporting a private namespace owned by another user", async () => {
+    findByUuidWithServers.mockResolvedValue(namespaceOwnedBy("other-user"));
+
+    const result = await namespacesImplementations.export(
+      { uuid: "ns-uuid" },
+      "user-1",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("Access denied");
+    // Must not read tools for a namespace the caller cannot access.
+    expect(findToolsByNamespaceUuid).not.toHaveBeenCalled();
+  });
+
+  it("returns not found when the namespace does not exist", async () => {
+    findByUuidWithServers.mockResolvedValue(null);
+
+    const result = await namespacesImplementations.export(
+      { uuid: "missing" },
+      "user-1",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("Namespace not found");
+  });
+
+  it("exports a namespace owned by the caller", async () => {
+    findByUuidWithServers.mockResolvedValue(namespaceOwnedBy("user-1"));
+
+    const result = await namespacesImplementations.export(
+      { uuid: "ns-uuid" },
+      "user-1",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data?.version).toBe(1);
+    expect(result.data?.namespace.name).toBe("release-manager");
+  });
+
+  it("exports a public namespace for any user", async () => {
+    findByUuidWithServers.mockResolvedValue(namespaceOwnedBy(null));
+
+    const result = await namespacesImplementations.export(
+      { uuid: "ns-uuid" },
+      "some-other-user",
+    );
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/apps/backend/src/trpc/namespaces.impl.ts
+++ b/apps/backend/src/trpc/namespaces.impl.ts
@@ -2,6 +2,7 @@ import {
   CreateNamespaceRequestSchema,
   CreateNamespaceResponseSchema,
   DeleteNamespaceResponseSchema,
+  ExportNamespaceResponseSchema,
   GetNamespaceResponseSchema,
   GetNamespaceToolsRequestSchema,
   GetNamespaceToolsResponseSchema,
@@ -33,6 +34,7 @@ import {
   mapOverrideNameToOriginal,
 } from "../lib/metamcp/metamcp-middleware/tool-overrides.functional";
 import { metaMcpServerPool } from "../lib/metamcp/metamcp-server-pool";
+import { buildNamespaceExport } from "./namespace-export";
 
 export const namespacesImplementations = {
   create: async (
@@ -234,6 +236,53 @@ export const namespacesImplementations = {
         success: false as const,
         data: [],
         message: "Failed to fetch namespace tools",
+      };
+    }
+  },
+
+  export: async (
+    input: {
+      uuid: string;
+    },
+    userId: string,
+  ): Promise<z.infer<typeof ExportNamespaceResponseSchema>> => {
+    try {
+      const namespaceWithServers =
+        await namespacesRepository.findByUuidWithServers(input.uuid);
+
+      if (!namespaceWithServers) {
+        return {
+          success: false as const,
+          message: "Namespace not found",
+        };
+      }
+
+      // Same access rule as get: owner or public namespace only
+      if (
+        namespaceWithServers.user_id &&
+        namespaceWithServers.user_id !== userId
+      ) {
+        return {
+          success: false as const,
+          message:
+            "Access denied: You can only export namespaces you own or public namespaces",
+        };
+      }
+
+      const toolsData = await namespacesRepository.findToolsByNamespaceUuid(
+        input.uuid,
+      );
+
+      return {
+        success: true as const,
+        data: buildNamespaceExport(namespaceWithServers, toolsData),
+        message: "Namespace exported successfully",
+      };
+    } catch (error) {
+      logger.error("Error exporting namespace:", error);
+      return {
+        success: false as const,
+        message: "Failed to export namespace",
       };
     }
   },

--- a/apps/frontend/app/[locale]/(sidebar)/namespaces/[uuid]/page.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/namespaces/[uuid]/page.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import { McpServerTypeEnum } from "@repo/zod-types";
-import { ArrowLeft, Calendar, Edit, Hash, Plug, Server } from "lucide-react";
+import {
+  ArrowLeft,
+  Calendar,
+  Download,
+  Edit,
+  Hash,
+  Plug,
+  Server,
+} from "lucide-react";
 import Link from "next/link";
 import { notFound, useRouter } from "next/navigation";
 import { use, useEffect, useRef, useState } from "react";
@@ -41,6 +49,7 @@ export default function NamespaceDetailPage({
 
   const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
   const [editDialogOpen, setEditDialogOpen] = useState<boolean>(false);
+  const [isExporting, setIsExporting] = useState<boolean>(false);
   const lastToggleTimeRef = useRef<number>(0);
 
   // Get tRPC utils for cache invalidation
@@ -123,6 +132,43 @@ export default function NamespaceDetailPage({
   // Handle delete namespace
   const handleDeleteNamespace = async () => {
     deleteMutation.mutate({ uuid });
+  };
+
+  // Handle exporting the namespace as a portable JSON document
+  const handleExportNamespace = async () => {
+    setIsExporting(true);
+    try {
+      const result = await utils.frontend.namespaces.export.fetch({ uuid });
+
+      if (!result.success || !result.data) {
+        toast.error(t("namespaces:detail.exportFailed"), {
+          description: result.message,
+        });
+        return;
+      }
+
+      const jsonString = JSON.stringify(result.data, null, 2);
+      const blob = new Blob([jsonString], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `namespace-${result.data.namespace.name}.json`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+
+      toast.success(t("namespaces:detail.namespaceExported"), {
+        description: t("namespaces:detail.namespaceExportedDescription"),
+      });
+    } catch (error) {
+      console.error("Error exporting namespace:", error);
+      toast.error(t("namespaces:detail.exportFailed"), {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      setIsExporting(false);
+    }
   };
 
   // Handle successful edit
@@ -351,6 +397,15 @@ export default function NamespaceDetailPage({
           </Button>
         </Link>
         <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleExportNamespace}
+            disabled={isExporting}
+          >
+            <Download className="h-4 w-4 mr-2" />
+            {t("namespaces:detail.exportNamespace")}
+          </Button>
           <Button
             variant="outline"
             size="sm"

--- a/apps/frontend/app/[locale]/(sidebar)/namespaces/[uuid]/page.tsx
+++ b/apps/frontend/app/[locale]/(sidebar)/namespaces/[uuid]/page.tsx
@@ -138,7 +138,12 @@ export default function NamespaceDetailPage({
   const handleExportNamespace = async () => {
     setIsExporting(true);
     try {
-      const result = await utils.frontend.namespaces.export.fetch({ uuid });
+      // staleTime: 0 forces a fresh fetch so the download always reflects the
+      // current namespace state, not a cached result (global staleTime is 5m).
+      const result = await utils.frontend.namespaces.export.fetch(
+        { uuid },
+        { staleTime: 0 },
+      );
 
       if (!result.success || !result.data) {
         toast.error(t("namespaces:detail.exportFailed"), {

--- a/apps/frontend/public/locales/en/namespaces.json
+++ b/apps/frontend/public/locales/en/namespaces.json
@@ -91,7 +91,11 @@
     "toggleTooFast": "Toggle Too Fast",
     "toggleTooFastDescription": "Please wait before toggling again to allow the session to initialize properly.",
     "forceReset": "Force Reset",
-    "anErrorOccurredWhileDeleting": "An error occurred while deleting the namespace"
+    "anErrorOccurredWhileDeleting": "An error occurred while deleting the namespace",
+    "exportNamespace": "Export",
+    "namespaceExported": "Namespace Exported",
+    "namespaceExportedDescription": "Namespace configuration has been downloaded",
+    "exportFailed": "Failed to export namespace"
   },
   "enhancedToolsTable": {
     "toolName": "Tool Name",

--- a/docs/en/concepts/namespaces.mdx
+++ b/docs/en/concepts/namespaces.mdx
@@ -111,6 +111,51 @@ Available tools through the namespace:
 - `git-helper__git_commit`
 - `git-helper__git_diff`
 
+## Exporting a Namespace
+
+You can export a namespace as a portable, versioned JSON document. This lets you
+store a namespace configuration in Git, review changes in a pull request, and
+promote a namespace between environments.
+
+1. **Open** the namespace detail page
+2. **Click** "Export"
+3. The browser downloads a `namespace-<name>.json` file
+
+The export document references servers and tools **by name**, so it is portable
+across MetaMCP instances. Key properties:
+
+- **No secrets**: server connection details (`env` values, bearer tokens, headers)
+  are never included. The document only references servers by name.
+- **Deterministic**: servers and tools are sorted by a stable key, so re-exporting
+  an unchanged namespace produces an identical file that is easy to diff.
+- **Deviations only**: a tool is listed only when it is `INACTIVE` or has an
+  override. Tools left in the default `ACTIVE` state with no override are omitted.
+
+Example export:
+
+```json
+{
+  "version": 1,
+  "exportedAt": "2026-07-31T10:00:00.000Z",
+  "namespace": {
+    "name": "release-manager",
+    "description": "Tools for release coordination",
+    "servers": [{ "name": "github", "status": "ACTIVE" }],
+    "tools": [
+      {
+        "server": "github",
+        "name": "create_pull_request",
+        "status": "ACTIVE",
+        "override": {
+          "description": "Create a pull request into the release branch."
+        }
+      },
+      { "server": "github", "name": "delete_repository", "status": "INACTIVE" }
+    ]
+  }
+}
+```
+
 ## Next Steps
 
 <CardGroup cols={2}>

--- a/docs/en/concepts/namespaces.mdx
+++ b/docs/en/concepts/namespaces.mdx
@@ -126,8 +126,10 @@ across MetaMCP instances. Key properties:
 
 - **No secrets**: server connection details (`env` values, bearer tokens, headers)
   are never included. The document only references servers by name.
-- **Deterministic**: servers and tools are sorted by a stable key, so re-exporting
-  an unchanged namespace produces an identical file that is easy to diff.
+- **Deterministic**: servers and tools are sorted by a stable, locale-independent
+  key, so re-exporting an unchanged namespace produces an identical `namespace`
+  body. Only the top-level `exportedAt` timestamp changes between exports, so
+  diffs stay small.
 - **Deviations only**: a tool is listed only when it is `INACTIVE` or has an
   override. Tools left in the default `ACTIVE` state with no override are omitted.
 

--- a/packages/trpc/src/routers/frontend/namespaces.ts
+++ b/packages/trpc/src/routers/frontend/namespaces.ts
@@ -2,6 +2,8 @@ import {
   CreateNamespaceRequestSchema,
   CreateNamespaceResponseSchema,
   DeleteNamespaceResponseSchema,
+  ExportNamespaceRequestSchema,
+  ExportNamespaceResponseSchema,
   GetNamespaceResponseSchema,
   GetNamespaceToolsRequestSchema,
   GetNamespaceToolsResponseSchema,
@@ -43,6 +45,10 @@ export const createNamespacesRouter = (
       input: z.infer<typeof GetNamespaceToolsRequestSchema>,
       userId: string,
     ) => Promise<z.infer<typeof GetNamespaceToolsResponseSchema>>;
+    export: (
+      input: z.infer<typeof ExportNamespaceRequestSchema>,
+      userId: string,
+    ) => Promise<z.infer<typeof ExportNamespaceResponseSchema>>;
     delete: (
       input: {
         uuid: string;
@@ -93,6 +99,14 @@ export const createNamespacesRouter = (
       .output(GetNamespaceToolsResponseSchema)
       .query(async ({ input, ctx }) => {
         return await implementations.getTools(input, ctx.user.id);
+      }),
+
+    // Protected: Export namespace as a portable, versioned JSON document
+    export: protectedProcedure
+      .input(ExportNamespaceRequestSchema)
+      .output(ExportNamespaceResponseSchema)
+      .query(async ({ input, ctx }) => {
+        return await implementations.export(input, ctx.user.id);
       }),
 
     // Protected: Create namespace

--- a/packages/zod-types/src/namespaces.zod.ts
+++ b/packages/zod-types/src/namespaces.zod.ts
@@ -178,6 +178,70 @@ export const RefreshNamespaceToolsResponseSchema = z.object({
   mappingsCreated: z.number().optional(),
 });
 
+// Namespace export/import format (portable, versioned, secret-free JSON).
+// Servers and tools are referenced by name so the document is portable across
+// instances; no server connection config (env / bearer token / headers) is included.
+export const NAMESPACE_EXPORT_VERSION = 1;
+
+export const NamespaceExportServerSchema = z.object({
+  name: z.string(),
+  status: McpServerStatusEnum,
+});
+
+export const NamespaceExportToolOverrideSchema = z.object({
+  name: z.string().optional(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  annotations: ToolAnnotationsSchema.optional(),
+});
+
+export const NamespaceExportToolSchema = z.object({
+  server: z.string(),
+  name: z.string(),
+  status: ToolStatusEnum,
+  override: NamespaceExportToolOverrideSchema.optional(),
+});
+
+export const NamespaceExportNamespaceSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  servers: z.array(NamespaceExportServerSchema),
+  tools: z.array(NamespaceExportToolSchema),
+});
+
+export const NamespaceExportSchema = z.object({
+  version: z.literal(NAMESPACE_EXPORT_VERSION),
+  exportedAt: z.string(),
+  namespace: NamespaceExportNamespaceSchema,
+});
+
+export const ExportNamespaceRequestSchema = z.object({
+  uuid: z.string(),
+});
+
+export const ExportNamespaceResponseSchema = z.object({
+  success: z.boolean(),
+  data: NamespaceExportSchema.optional(),
+  message: z.string().optional(),
+});
+
+export type NamespaceExportServerEntry = z.infer<
+  typeof NamespaceExportServerSchema
+>;
+export type NamespaceExportToolOverride = z.infer<
+  typeof NamespaceExportToolOverrideSchema
+>;
+export type NamespaceExportToolEntry = z.infer<
+  typeof NamespaceExportToolSchema
+>;
+export type NamespaceExport = z.infer<typeof NamespaceExportSchema>;
+export type ExportNamespaceRequest = z.infer<
+  typeof ExportNamespaceRequestSchema
+>;
+export type ExportNamespaceResponse = z.infer<
+  typeof ExportNamespaceResponseSchema
+>;
+
 // Type exports
 export type CreateNamespaceRequest = z.infer<
   typeof CreateNamespaceRequestSchema


### PR DESCRIPTION
## Problem

Namespace configuration (member servers, per-tool ACTIVE/INACTIVE state, tool overrides) lives only in Postgres and is only reachable through the admin UI. It cannot be reviewed in a pull request, promoted between environments, diffed, or rebuilt from source control. This PR adds the export half of #340.

## Approach

Adds a `frontend.namespaces.export` protected query that returns a portable JSON document for a namespace, plus an Export button on the namespace detail page that downloads it. It mirrors the existing `mcpServers` export/import and the namespace read/authorization patterns. The core logic is a pure `buildNamespaceExport` function, which keeps it easy to unit test.

The export is also exposed as an admin MCP tool (`metamcp_export_namespace`), consistent with how the other namespace operations and the MCP server bulk import are already surfaced in `ADMIN_TOOLS`.

## Format

- **Name-based, never UUID** — servers and tools are referenced by name so the document is portable across instances.
- **No secrets** — `env` values, bearer tokens, and headers are never emitted; the document embeds no server connection config.
- **Deterministic** - sorting compares every exported field with a locale-independent (code-unit) key, object key order is fixed, and override annotation keys are sorted, so the `namespace` body is byte-identical across exports of an unchanged namespace. This holds even when a namespace contains two servers sharing a name (possible because server names are unique per user), where database row order would otherwise leak into the output. Only the top-level `exportedAt` provenance timestamp varies between exports, so diffs stay small.
- **Deviations only** — a tool is listed only when it is `INACTIVE` or has an override. Tools left in the default `ACTIVE` state with no override are omitted.
- Includes a `version` field so the format can evolve.

Example:

```json
{
  "version": 1,
  "exportedAt": "2026-07-31T10:00:00.000Z",
  "namespace": {
    "name": "release-manager",
    "description": "Tools for release coordination",
    "servers": [{ "name": "github", "status": "ACTIVE" }],
    "tools": [
      {
        "server": "github",
        "name": "create_pull_request",
        "status": "ACTIVE",
        "override": { "description": "Create a pull request into the release branch." }
      },
      { "server": "github", "name": "delete_repository", "status": "INACTIVE" }
    ]
  }
}
```

## Out of scope

Import (planned as a follow-up PR); endpoints; embedding server or secret config; auto-discovery of tools; any change to tool-override business logic. **No database schema changes.**

## How to test

- Automated: `cd apps/backend && pnpm test` — unit tests cover the full/empty namespace shape, secret exclusion, output determinism, annotation-key ordering, and authorization (a user cannot export a namespace they do not own).
- Manual: open a namespace, click **Export**, and confirm the downloaded JSON contains no secrets. Re-export and confirm the file is identical. Confirm that exporting a namespace you do not own is denied.

Refs #340

