### PR TITLE
Docs: optional TOA verify before MetaMCP enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,10 @@ If you want to deploy it to a online service or a VPS, a instance of at least 2G
 
 Since MCP leverages SSE for long connection, if you are using reverse proxy like nginx, please refer to an example setup [nginx.conf.example](nginx.conf.example)
 
+## Optional: Tool Outcome Attestation (TOA) before enable
+
+MetaMCP aggregates and authorizes MCP servers. [TOA](https://github.com/Carmel-Labs-Inc/toa) (`toa/0.1`) is optional offline delivery evidence before enabling a server in a namespace. It is not per-call signing. Docs: [Optional TOA verify gate](docs/en/deployment/toa-optional-gate.mdx) · example: [`examples/toa-after-aggregate.yml`](examples/toa-after-aggregate.yml).
+
 ## 🏗️ Architecture
 
 - **Frontend**: Next.js

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -10,7 +10,7 @@
     "light": "/favicon.png",
     "dark": "/favicon.png"
   },
-  "icons":{
+  "icons": {
     "library": "lucide"
   },
   "colors": {
@@ -58,7 +58,8 @@
           {
             "group": "Deployment",
             "pages": [
-              "en/deployment/custom-deployment"
+              "en/deployment/custom-deployment",
+              "en/deployment/toa-optional-gate"
             ]
           },
           {
@@ -91,14 +92,14 @@
         "language": "cn",
         "groups": [
           {
-            "group": "快速开始",
+            "group": "\u5feb\u901f\u5f00\u59cb",
             "pages": [
               "cn/index",
               "cn/quickstart"
             ]
           },
           {
-            "group": "核心概念",
+            "group": "\u6838\u5fc3\u6982\u5ff5",
             "pages": [
               "cn/concepts/mcp-servers",
               "cn/concepts/namespaces",
@@ -109,13 +110,13 @@
             ]
           },
           {
-            "group": "部署",
+            "group": "\u90e8\u7f72",
             "pages": [
               "cn/deployment/custom-deployment"
             ]
           },
           {
-            "group": "集成",
+            "group": "\u96c6\u6210",
             "pages": [
               "cn/integrations/cursor",
               "cn/integrations/claude-desktop",
@@ -125,7 +126,7 @@
             ]
           },
           {
-            "group": "开发",
+            "group": "\u5f00\u53d1",
             "pages": [
               "cn/development/contributing",
               "cn/development/i18n",
@@ -133,7 +134,7 @@
             ]
           },
           {
-            "group": "故障排除",
+            "group": "\u6545\u969c\u6392\u9664",
             "pages": [
               "cn/troubleshooting/oauth-troubleshooting"
             ]

--- a/docs/en/concepts/mcp-servers.mdx
+++ b/docs/en/concepts/mcp-servers.mdx
@@ -497,6 +497,12 @@ Custom dependencies increase the Docker image size and startup time. Consider us
   </Accordion>
 </AccordionGroup>
 
+## Optional: Tool Outcome Attestation (TOA) before enable
+
+Configuring and starting a server proves MetaMCP can launch it. [TOA](https://github.com/Carmel-Labs-Inc/toa) is adjacent delivery evidence you can verify offline before enabling that server in a production namespace. Optional and off by default. No AgentStatus account is required to verify.
+
+See [Optional TOA verify gate](/en/deployment/toa-optional-gate).
+
 ## Next Steps
 
 <CardGroup cols={2}>

--- a/docs/en/deployment/toa-optional-gate.mdx
+++ b/docs/en/deployment/toa-optional-gate.mdx
@@ -20,7 +20,7 @@ Optional, off by default. Before enabling a new MCP server in a namespace (or pr
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 

--- a/docs/en/deployment/toa-optional-gate.mdx
+++ b/docs/en/deployment/toa-optional-gate.mdx
@@ -9,7 +9,7 @@ MetaMCP aggregates MCP servers into namespaces and endpoints, with middleware fo
 
 ## Suggested fit
 
-Optional, off by default. Before enabling a new MCP server in a namespace (or promoting an endpoint to production), require a recent attestation and verify it offline with a pinned emitter public key.
+Optional, off by default. Before enabling a new MCP server in a namespace (or promoting an endpoint to production), require an attestation and verify it offline with `--require-emitter` and optional `--max-age`.
 
 - Any party can emit if they sign the schema.
 - AgentStatus is one optional emitter.
@@ -20,8 +20,8 @@ Optional, off by default. Before enabling a new MCP server in a namespace (or pr
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 
 Copy-paste workflow: `examples/toa-after-aggregate.yml` in this repository.

--- a/docs/en/deployment/toa-optional-gate.mdx
+++ b/docs/en/deployment/toa-optional-gate.mdx
@@ -1,0 +1,37 @@
+---
+title: "Optional TOA verify gate"
+description: "Offline Tool Outcome Attestation before enabling an aggregated MCP server"
+---
+
+MetaMCP aggregates MCP servers into namespaces and endpoints, with middleware for filtering and policy. That answers federation and access. It does not prove that a tool recently delivered a real result under an outside probe.
+
+[TOA](https://github.com/Carmel-Labs-Inc/toa) (`toa/0.1`) is an Apache-2.0 signed JSON evidence format for MCP tool delivery (reach, invoke, functional, shape, and related layers). It is not a wire protocol. It is not meant to run on every live `tools/call`.
+
+## Suggested fit
+
+Optional, off by default. Before enabling a new MCP server in a namespace (or promoting an endpoint to production), require a recent attestation and verify it offline with a pinned emitter public key.
+
+- Any party can emit if they sign the schema.
+- AgentStatus is one optional emitter.
+- No AgentStatus account is required to verify.
+
+```yaml
+      # After your MetaMCP config / smoke checks for a new server.
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass
+```
+
+Copy-paste workflow: `examples/toa-after-aggregate.yml` in this repository.
+
+## Out of scope
+
+- Replacing MetaMCP middleware, auth, or rate limits
+- Signing every production `tools/call`
+- Changing the aggregator hot path
+
+<Card title="MCP Servers" icon="server" href="/en/concepts/mcp-servers">
+  How to configure servers that you might gate with TOA
+</Card>

--- a/examples/toa-after-aggregate.yml
+++ b/examples/toa-after-aggregate.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d

--- a/examples/toa-after-aggregate.yml
+++ b/examples/toa-after-aggregate.yml
@@ -1,0 +1,24 @@
+# Example only. Copy into your org workflow as needed.
+# After adding an MCP server to a MetaMCP namespace, optionally verify TOA.
+name: MetaMCP aggregate and optional TOA
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "**/mcp*.json"
+      - "toa.json"
+
+jobs:
+  toa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Your MetaMCP config validation / smoke tests go here.
+
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass

--- a/examples/toa-after-aggregate.yml
+++ b/examples/toa-after-aggregate.yml
@@ -20,5 +20,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d


### PR DESCRIPTION
## Summary

Docs-only. Optional offline `toa-verify` before enabling an aggregated MCP server in a MetaMCP namespace.

- `docs/en/deployment/toa-optional-gate.mdx` + Mintlify nav entry
- Pointer in `docs/en/concepts/mcp-servers.mdx`
- `examples/toa-after-aggregate.yml`
- README pointer

Does not change runtime aggregation or middleware. TOA (`toa/0.1`) is adjacent delivery evidence, not a wire protocol and not per-call signing. No AgentStatus account is required to verify.

## Test plan

- [ ] Mintlify page appears under Deployment
- [ ] Example YAML is clearly optional / gated on `toa.json`
- [ ] Copy does not claim TOA replaces MetaMCP middleware or auth


Made with [Cursor](https://cursor.com)