### PR TITLE
fix(oauth): RFC-compliant issuer and loopback redirect URIs

### DIFF
--- a/apps/backend/src/routers/oauth/metadata.ts
+++ b/apps/backend/src/routers/oauth/metadata.ts
@@ -98,9 +98,10 @@ metadataRouter.get(
     try {
       const baseUrl = getBaseUrl(req);
 
-      // Ensure the issuer URL has a trailing slash for OAuth validation
-      // This is required by RFC 8414 and RFC 9728 for exact matching
-      const issuerUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+      // The issuer MUST be identical to the issuer identifier the client used
+      // to build this well-known URL (RFC 8414 section 3.3), which carries no
+      // trailing slash. Appending one makes clients reject the document.
+      const issuerUrl = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
 
       const metadata = {
         // Issuer identifier (required by RFC 8414)

--- a/apps/backend/src/routers/oauth/utils.test.ts
+++ b/apps/backend/src/routers/oauth/utils.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { validateRedirectUri } from "./utils";
+
+describe("validateRedirectUri", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  describe("in production", () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = "production";
+    });
+
+    // RFC 8252 section 7.3 / OAuth 2.1: native clients listen on a loopback
+    // port chosen at runtime and redirect there over plain http. The MCP spec
+    // builds on this, so rejecting these makes OAuth unusable for MCP clients.
+    it.each([
+      "http://localhost:3118/callback",
+      "http://127.0.0.1:51000/callback",
+      "http://[::1]:51000/callback",
+    ])("accepts the loopback redirect %s", (uri) => {
+      expect(validateRedirectUri(uri)).toBe(true);
+    });
+
+    it("accepts an https redirect on a public host", () => {
+      expect(validateRedirectUri("https://example.com/callback")).toBe(true);
+    });
+
+    it("rejects plain http on a non-loopback host", () => {
+      expect(validateRedirectUri("http://example.com/callback")).toBe(false);
+    });
+
+    it.each([
+      "http://192.168.1.50/callback",
+      "http://10.0.0.5/callback",
+      "http://172.16.0.5/callback",
+      "https://192.168.1.50/callback",
+    ])("rejects the private-network address %s", (uri) => {
+      expect(validateRedirectUri(uri)).toBe(false);
+    });
+
+    it("does not treat a host that merely starts with localhost as loopback", () => {
+      expect(validateRedirectUri("http://localhost.example.com/cb")).toBe(
+        false,
+      );
+    });
+
+    it.each(["ftp://localhost/callback", "javascript:alert(1)", "not a url"])(
+      "rejects %s",
+      (uri) => {
+        expect(validateRedirectUri(uri)).toBe(false);
+      },
+    );
+
+    it("still honours an explicit allowed-hosts list", () => {
+      expect(
+        validateRedirectUri("https://example.com/cb", ["other.example.com"]),
+      ).toBe(false);
+      expect(
+        validateRedirectUri("https://example.com/cb", ["example.com"]),
+      ).toBe(true);
+    });
+  });
+
+  describe("outside production", () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = "development";
+    });
+
+    it("allows plain http on any host", () => {
+      expect(validateRedirectUri("http://example.com/callback")).toBe(true);
+      expect(validateRedirectUri("http://localhost:3000/callback")).toBe(true);
+    });
+
+    it("still rejects non-http(s) schemes", () => {
+      expect(validateRedirectUri("ftp://example.com/callback")).toBe(false);
+    });
+  });
+});

--- a/apps/backend/src/routers/oauth/utils.ts
+++ b/apps/backend/src/routers/oauth/utils.ts
@@ -74,27 +74,40 @@ export function validateRedirectUri(
       return false;
     }
 
-    // For production, only allow HTTPS
+    // URL.hostname keeps the brackets around an IPv6 literal ("[::1]"), so
+    // strip them before comparing against loopback addresses.
+    const hostname = parsedUri.hostname
+      .toLowerCase()
+      .replace("[", "")
+      .replace("]", "");
+
+    // Native/public clients redirect to a loopback listener on a port they
+    // pick at runtime. RFC 8252 section 7.3 and OAuth 2.1 require that these
+    // be accepted over plain http, and the MCP spec relies on it — every MCP
+    // client registers something like http://127.0.0.1:PORT/callback.
+    const isLoopback =
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1";
+
+    // Outside of loopback, production only allows HTTPS
     if (
       process.env.NODE_ENV === "production" &&
-      parsedUri.protocol !== "https:"
+      parsedUri.protocol !== "https:" &&
+      !isLoopback
     ) {
       return false;
     }
 
-    // Prevent localhost/private IPs in production
-    if (process.env.NODE_ENV === "production") {
-      const hostname = parsedUri.hostname.toLowerCase();
-      if (
-        hostname === "localhost" ||
-        hostname === "127.0.0.1" ||
-        hostname === "::1" ||
-        hostname.startsWith("192.168.") ||
+    // Prevent private IPs in production
+    if (
+      process.env.NODE_ENV === "production" &&
+      !isLoopback &&
+      (hostname.startsWith("192.168.") ||
         hostname.startsWith("10.") ||
-        hostname.startsWith("172.")
-      ) {
-        return false;
-      }
+        hostname.startsWith("172."))
+    ) {
+      return false;
     }
 
     // Check against allowed hosts if provided


### PR DESCRIPTION
Two independent bugs in the OAuth router make MetaMCP unreachable over OAuth for MCP clients. Both are cases where the code does the opposite of what its own comment claims the RFC requires. I hit them in sequence on a self-hosted instance: fixing the first only exposed the second.

Both are reproducible on `ai-dev` and on the published `ghcr.io/metatool-ai/metamcp:latest` (v2.4.22).

## 1. `issuer` carried a trailing slash

`GET /.well-known/oauth-authorization-server` returned:

```json
{ "issuer": "https://metamcp.example.com/" }
```

RFC 8414 section 3.3 requires the `issuer` value to be identical to the issuer identifier the client used to build the well-known URL, which has no trailing slash. The code appended one deliberately:

```ts
// Ensure the issuer URL has a trailing slash for OAuth validation
// This is required by RFC 8414 and RFC 9728 for exact matching
const issuerUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
```

Every other field in the same document already used the unmodified `baseUrl`, so only `issuer` was affected — including `authorization_servers` in the protected-resource document, which therefore disagreed with `issuer`.

Clients refuse the document outright. Claude Code reports:

```
Failed to connect — Issuer mismatch in authorization server metadata
(RFC 8414 §3.3): expected "https://metamcp.example.com",
received "https://metamcp.example.com/"
```

## 2. Loopback redirect URIs were rejected

With `NODE_ENV=production`, `validateRedirectUri` rejected both the `http` scheme and the hosts `localhost` / `127.0.0.1` / `::1`. Dynamic Client Registration answered every native client with:

```json
{
  "error": "invalid_redirect_uri",
  "error_description": "Invalid redirect URI: http://localhost:3118/callback. Must use secure scheme and valid format."
}
```

RFC 8252 section 7.3 and OAuth 2.1 require loopback redirects over plain `http` for native public clients: such a client cannot hold a secret and listens on a port it picks at runtime. The MCP authorization spec builds on this, so in practice every MCP client — Claude Code, the MCP Inspector, and others — registers a loopback callback and is turned away.

After the change, `http` is accepted **only** on a loopback host. Plain `http` on any other host stays rejected, and the private-network ranges (`192.168.` / `10.` / `172.`) stay rejected exactly as before.

This also strips the brackets from an IPv6 literal before comparing. `URL` exposes `hostname` as `[::1]`, so the existing `"::1"` comparison never matched anything.

## Verification

- `apps/backend/src/routers/oauth/utils.test.ts` is new: 16 cases covering loopback acceptance, the rejections that must stay in place, non-http(s) schemes, the `allowedHosts` path, and non-production behaviour. Reverting `utils.ts` fails exactly the three loopback cases and leaves the rest green.
- Backend suite: 203 tests across 14 files pass. `tsc --noEmit` is clean, `eslint` reports nothing on the touched files.
- Both fixes were also confirmed live against a self-hosted instance behind a reverse proxy: `issuer` now matches the base URL, DCR accepts `http://localhost:PORT/callback` and still rejects `http://evil.example.com/cb`, and the client moves from "Issuer mismatch" through to the normal browser sign-in step.

## Not included

`/.well-known/oauth-protected-resource` applies the same trailing-slash treatment to `resource`. That one is a separate question under RFC 9728 and no client complained about it, so I left it alone rather than widen this PR — happy to fold it in if you'd like it addressed here.
